### PR TITLE
Bugfix: Amount of particles now constant when resizing

### DIFF
--- a/windy.js
+++ b/windy.js
@@ -16,7 +16,7 @@ var Windy = function( params ){
   var MAX_WIND_INTENSITY = 40;              // wind velocity at which particle intensity is maximum (m/s)
   var MAX_PARTICLE_AGE = 100;                // max number of frames a particle is drawn before regeneration
   var PARTICLE_LINE_WIDTH = 0.8;              // line width of a drawn particle
-  var PARTICLE_MULTIPLIER = 8;              // particle count scalar (completely arbitrary--this values looks nice)
+  var PARTICLE_MULTIPLIER = 1/30;              // particle count scalar (completely arbitrary--this values looks nice)
   var PARTICLE_REDUCTION = 0.75;            // reduce particle count to this much of normal for mobile devices
   var FRAME_RATE = 20;                      // desired milliseconds per frame
   var BOUNDARY = 0.45;
@@ -363,7 +363,7 @@ var Windy = function( params ){
     var colorStyles = windIntensityColorScale(INTENSITY_SCALE_STEP, MAX_WIND_INTENSITY);
     var buckets = colorStyles.map(function() { return []; });
 
-    var particleCount = Math.round(bounds.width * PARTICLE_MULTIPLIER);
+    var particleCount = Math.round(bounds.width * bounds.height * PARTICLE_MULTIPLIER);
     if (isMobile()) {
       particleCount *= PARTICLE_REDUCTION;
     }


### PR DESCRIPTION
In previous version amount of particles depended on width of canvas only. It caused funny changes of particle density when resizing height of a map. Now density is dependent on w \* h of canvas and does not change with resizing. Constant PARTICLE MULTIPLIER must also reflect that.
